### PR TITLE
Allow transport info peername to return a tuple

### DIFF
--- a/sstpd/sstp.py
+++ b/sstpd/sstp.py
@@ -59,6 +59,8 @@ class SSTPProtocol(Protocol):
         peer = self.transport.get_extra_info("peername")
         if hasattr(peer, 'host'):
             self.remote_host = str(peer.host)
+        elif type(peer) == tuple:
+            self.remote_host = peer[0]
 
 
     def data_received(self, data):


### PR DESCRIPTION
Define remote_host correctly in case the peername (extra) info returns a
tuple instead of a (dictionary) object with attribute 'host'.

The tuple consists of the client's IP adresss and port number
respectively.

Signed-off-by: Tijs Van Buggenhout <tijs.van.buggenhout@axsguard.com>