### PR TITLE
Allow to limit the network subnet to a given range

### DIFF
--- a/sstpd/__main__.py
+++ b/sstpd/__main__.py
@@ -83,6 +83,10 @@ def _get_args():
             metavar='NETWORK',
             help="Enable internal IP management. Client's IP will be selected "
                  "from NETWORK (e.g. 192.168.20.0/24).")
+    parser.add_argument('--range',
+            metavar='RANGE',
+            help="Limit remote NETWORK to given RANGE (e.g. 192.168.20.10-20 "
+            "or 192.168.20.10-192.168.20.20)")
     parser.add_argument('--ciphers',
             metavar="CIPHER-LIST",
             help='Custom OpenSSL cipher suite. See ciphers(1).')
@@ -119,9 +123,11 @@ def main():
     logging.addLevelName(5, 'VERBOSE')
 
     if args.remote:
-        ippool = IPPool(args.remote)
+        ippool = IPPool(args.remote, args.range)
         ippool.register(args.local)
     else:
+        if args.range:
+            logging.warning('RANGE given without remote NETWORK - ignored.')
         ippool = None
 
     if args.no_ssl:


### PR DESCRIPTION
Similar to other VPN daemons, like pptp and l2tp. Gives more flexibility
than working solely with network subnets.

A larger subnet is maintained, yet the IP pool is restricted to a small
range within. Furthermore it supports ranges that would otherwise fall
into distinct subnets, eg. 192.168.21.200-192.168.22.200/22.

Signed-off-by: Tijs Van Buggenhout <tijs.van.buggenhout@axsguard.com>