### PR TITLE
Set remote_host to first IP in X-Forwarded-For header

### DIFF
--- a/sstpd/__main__.py
+++ b/sstpd/__main__.py
@@ -67,7 +67,8 @@ def _get_args():
     parser.add_argument('-n', '--no-ssl',
             action='store_true',
             help='Use plain HTTP instead of HTTPS. '
-                 'Useful when running behind a reverse proxy.')
+                 'Useful when running behind a reverse proxy.'
+                 'Enables X-Forwarded-For HTTP header processing.')
     parser.add_argument('--proxy-protocol',
             action='store_true',
             help='Enable PROXY PROTOCOL, imply --no-ssl')

--- a/sstpd/sstp.py
+++ b/sstpd/sstp.py
@@ -143,7 +143,8 @@ class SSTPProtocol(Protocol):
             try:
                 hosts = header.decode('ascii').split(':')[1]
                 host = hosts.split(',')[0]
-                self.remote_host = host.strip()
+                if self.factory.use_http_proxy:
+                    self.remote_host = host.strip()
             except:
                 pass
         self.transport.write(b'HTTP/1.1 200 OK\r\n'
@@ -620,6 +621,7 @@ class SSTPProtocolFactory:
                 [has_plugin.returncode == 0]
         self.local = config.local
         self.proxy_protocol = config.proxy_protocol
+        self.use_http_proxy = (config.no_ssl and not config.proxy_protocol)
         self.remote_pool = remote_pool
         self.cert_hash = cert_hash
 

--- a/sstpd/sstp.py
+++ b/sstpd/sstp.py
@@ -128,7 +128,8 @@ class SSTPProtocol(Protocol):
             if len(self.receive_buf) > HTTP_REQUEST_BUFFER_SIZE:
                 close('Request too large, may not a valid HTTP request.')
             return
-        request_line = self.receive_buf.split(b'\r\n')[0]
+        headers = self.receive_buf.split(b'\r\n')
+        request_line = headers[0]
         self.receive_buf.clear()
         try:
             method, uri, version = request_line.split()
@@ -138,6 +139,13 @@ class SSTPProtocol(Protocol):
             return close('Unexpected HTTP method (%s) and/or version (%s).',
                          method.decode(errors='replace'),
                          version.decode(errors='replace'))
+        for header in filter(lambda x: b'x-forwarded-for' in x.lower(), headers):
+            try:
+                hosts = header.decode('ascii').split(':')[1]
+                host = hosts.split(',')[0]
+                self.remote_host = host.strip()
+            except:
+                pass
         self.transport.write(b'HTTP/1.1 200 OK\r\n'
                 b'Content-Length: 18446744073709551615\r\n'
                 b'Server: SSTP-Server/%s\r\n\r\n' % str(__version__).encode())


### PR DESCRIPTION
When running sstp-server behind an HTTP (reverse) proxy, the IP
address/host determined from the transport (info) peername is the one
from the proxy server, rather than from the original peer.

An HTTP reverse proxy may forward the (list of) IP addresses of a peer
connection in the X-Forwarded-For HTTP header. If so detected by
sstp-server, set the remote_host to the first (originator) IP address
from that list.

Signed-off-by: Tijs Van Buggenhout <tijs.van.buggenhout@axsguard.com>