### PR TITLE
Topic/verify crypto binding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Requirements
 
 For Python 2.7, use v0.4.x
 
+**Crypto Binding** is supported using *SSTP ppp API* plug-in sstp-pppd-plugin.so from `sstp-client <http://sstp-client.sourceforge.net/>`_.
+
 Install
 -------
 
@@ -65,7 +67,6 @@ Or:
 Known Issues
 ------------
 
-- Not implemented *Crypto Binding* yet. Potential MITM attack risk exists.
 - High CPU usage, may not suitable for high thougthput applications.
 
 License

--- a/sstpd/__main__.py
+++ b/sstpd/__main__.py
@@ -132,8 +132,8 @@ def main():
             ssl_ctx.set_ciphers(args.ciphers)
     if args.pem_cert:
         cert_hash = certtool.get_fingerprint(args.pem_cert)
-        logging.debug('Cert SHA-1: %s', hexlify(cert_hash.sha1).decode())
-        logging.debug('Cert SHA-256: %s', hexlify(cert_hash.sha256).decode())
+        logging.info('Cert SHA-1: %s', hexlify(cert_hash.sha1).decode())
+        logging.info('Cert SHA-256: %s', hexlify(cert_hash.sha256).decode())
     else:
         cert_hash = None
         logging.warning('--pem_cert not given, hash checking disabled')

--- a/sstpd/ppp.py
+++ b/sstpd/ppp.py
@@ -2,6 +2,7 @@ import os
 import logging
 from struct import pack
 import asyncio
+from binascii import hexlify
 
 from .constants import VERBOSE
 from .codec import escape, PppDecoder
@@ -107,4 +108,123 @@ class PPPDProtocolFactory:
         proto = PPPDProtocol()
         proto.sstp = self.sstp
         proto.remote = self.remote
+        return proto
+
+
+class PPPDSSTPAPIProtocol(asyncio.Protocol):
+    SSTP_API_MSG_UNKNOWN = 0
+    SSTP_API_MSG_AUTH    = 1
+    SSTP_API_MSG_ADDR    = 2
+    SSTP_API_MSG_ACK     = 3
+
+    message_str = {
+            SSTP_API_MSG_UNKNOWN: 'SSTP_API_MSG_UNKNOWN',
+            SSTP_API_MSG_AUTH:    'SSTP_API_MSG_AUTH',
+            SSTP_API_MSG_ADDR:    'SSTP_API_MSG_ADDR',
+            SSTP_API_MSG_ACK:     'SSTP_API_MSG_ACK', }
+
+    SSTP_API_ATTR_UNKNOWN   = 0
+    SSTP_API_ATTR_MPPE_SEND = 1
+    SSTP_API_ATTR_MPPE_RECV = 2
+    SSTP_API_ATTR_GATEWAY   = 3
+    SSTP_API_ATTR_ADDR      = 4
+
+    attribute_str = {
+            SSTP_API_ATTR_UNKNOWN:   'SSTP_API_ATTR_UNKNOWN',
+            SSTP_API_ATTR_MPPE_SEND: 'SSTP_API_ATTR_MPPE_SEND',
+            SSTP_API_ATTR_MPPE_RECV: 'SSTP_API_ATTR_MPPE_RECV',
+            SSTP_API_ATTR_GATEWAY:   'SSTP_API_ATTR_GATEWAY',
+            SSTP_API_ATTR_ADDR:      'SSTP_API_ATTR_ADDR', }
+
+    def __init__(self):
+        self.sstp = None
+        self.master_send_key = None
+        self.master_recv_key = None
+
+    def connection_made(self, transport):
+        sockname = transport.get_extra_info('sockname')
+        logging.info('Initiate PPP SSTP API protocol on %s.', sockname)
+        self.transport = transport
+
+    def message_type(self, mtype):
+        return self.message_str.get(mtype,
+                self.message_str[self.SSTP_API_MSG_UNKNOWN])
+
+    def is_auth_message(self, mtype):
+        return mtype is self.SSTP_API_MSG_AUTH
+
+    def attribute_type(self, atype):
+        return self.attribute_str.get(atype,
+                self.attribute_str[self.SSTP_API_ATTR_UNKNOWN])
+
+    def is_mppe_send_attribute(self, atype):
+        return atype is self.SSTP_API_ATTR_MPPE_SEND
+
+    def is_mppe_recv_attribute(self, atype):
+        return atype is self.SSTP_API_ATTR_MPPE_RECV
+
+    def handle_attribute(self, atype, adata):
+        if self.is_mppe_send_attribute(atype):
+            self.master_send_key = adata
+            if __debug__:
+                logging.debug("PPP master send key %s",
+                        hexlify(self.master_send_key))
+        elif self.is_mppe_recv_attribute(atype):
+            self.master_recv_key = adata
+            if __debug__:
+                logging.debug("PPP master receive key %s",
+                        hexlify(self.master_recv_key))
+
+    def message_parse(self, message):
+        idx = 0
+        while idx < len(message):
+            if (idx + 4 > len(message)):
+                break
+            atype = (message[idx+1] << 8) | message[idx]
+            alen = (message[idx+3] << 8) | message[idx+2]
+            logging.debug("SSTP API message - attribute %s (len: %d)",
+                    self.attribute_type(atype), alen)
+            idx += 4
+            self.handle_attribute(atype, message[idx:idx + alen])
+            idx += alen
+
+        return (idx == len(message))
+
+    def data_received(self, message):
+        # magic 'sstp' as 32-bits integer in network order
+        magic = b'\x70\x74\x73\x73'
+        # ack whatever received and close connection
+        ack = magic + b'\x00\x00' + b'\x03\x00'
+        self.transport.write(ack)
+        self.close()
+        if message[0:4] != magic:
+            logging.error("SSTP API message - invalid magic %a.", message[0:4])
+            return
+        length = (message[5] << 8) | message[4]
+        if length + 8 != len(message):
+            logging.error("SSTP API message - incorrect length.")
+            return
+        if not self.message_parse(message[8:]) :
+            logging.error("SSTP API message - failed parsing attributes.")
+            return
+        mtype = (message[7] << 8) | message[6]
+        if self.is_auth_message(mtype):
+            if (self.master_send_key is None or
+                    self.master_recv_key is None):
+                logging.error("SSTP API message - missing master "
+                        "send and/or receive key.")
+                return
+
+    def close(self):
+        logging.info('Finished PPP SSTP API protocol.')
+        self.transport.close()
+
+
+class PPPDSSTPPluginFactory:
+    def __init__(self, callback):
+        self.sstp = callback
+
+    def __call__(self):
+        proto = PPPDSSTPAPIProtocol()
+        proto.sstp = self.sstp
         return proto

--- a/sstpd/ppp.py
+++ b/sstpd/ppp.py
@@ -214,6 +214,8 @@ class PPPDSSTPAPIProtocol(asyncio.Protocol):
                 logging.error("SSTP API message - missing master "
                         "send and/or receive key.")
                 return
+        self.sstp.higher_layer_authentication_key(
+                self.master_send_key, self.master_recv_key)
 
     def close(self):
         logging.info('Finished PPP SSTP API protocol.')

--- a/sstpd/sstp.py
+++ b/sstpd/sstp.py
@@ -271,6 +271,8 @@ class SSTPProtocol(Protocol):
             return
         if self.state != State.SERVER_CALL_CONNECTED_PENDING:
             self.abort(ATTRIB_STATUS_UNACCEPTED_FRAME_RECEIVED)
+            return
+
         # TODO: check cert_hash and mac_hash
         logging.debug("Received cert hash: %s", hexlify(cert_hash).decode())
         logging.debug("Received MAC hash: %s", hexlify(mac_hash).decode())


### PR DESCRIPTION
Includes the axsguard/sstp-server topic/call_connected_improvements branch

Uses the sstp-pppd-plugin.so from [sstp-client](http://sstp-client.sourceforge.net/) if available to support crypto-binding. This ppp plugin snoops the mppe keys from the ppp (higher) layer and leverages them over a unix socket to the sstp-server. These HLAK keys are necessary to (re)compute the Client MAC (CMAC) for verification.

Only when the computed CMAC matches the one provided by the client the connection can be trusted to have no man-in-the-middle.

Originally I used the Openssl library (before certtool) to obtain the certificate's fingerprints, like so:

```diff
--- a/sstpd/__main__.py
+++ b/sstpd/__main__.py
@@ -6,6 +6,7 @@ from socket import IPPROTO_TCP, TCP_NODE
 from configparser import SafeConfigParser, NoSectionError
 import ssl
 import asyncio
+from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 try:
     import uvloop
 except ImportError:
@@ -126,18 +127,34 @@ def main():
     else:
         ippool = None
 
+    if args.pem_cert is not None:
+        try:
+            with open(args.pem_cert, "rb") as cert_file:
+                cert = load_certificate(FILETYPE_PEM, cert_file.read())
+            sha1 = b''
+            try:
+                sha1 = bytes.fromhex(cert.digest('sha1').decode().replace(':', ' '))
+            except:
+                pass
+            sha256 = b''
+            try:
+                sha256 = bytes.fromhex(cert.digest('sha256').decode().replace(':', ' '))
+            except:
+                pass
+            logging.info("Certificate SHA1 %s", sha1.hex())
+            logging.info("Certificate SHA256 %s", sha256.hex())
+            cert_hash = (sha1, sha256)
+        except:
+            cert_hash = None
+            pass
+
     if args.no_ssl:
         ssl_ctx = None
-        cert_hash = None
         logging.info('Running without SSL.')
     else:
         ssl_ctx = _load_cert(args.pem_cert, args.pem_key)
         if args.ciphers:
             ssl_ctx.set_ciphers(args.ciphers)
-        #sha1 = cert.digest('sha1').replace(':', '').decode('hex')
-        #sha256 = cert.digest('sha256').replace(':', '').decode('hex')
-        # TODO: set cert hash on cert_hash[sha1, sha256]
-        cert_hash = None
     on_unix_socket = args.listen.startswith('/')
 
     if uvloop is None:
```