### PR TITLE
Fix exceptions in rump connections.

### DIFF
--- a/sstpd/sstp.py
+++ b/sstpd/sstp.py
@@ -64,6 +64,7 @@ class SSTPProtocol(Protocol):
         self.hlak = None
         # Client Compound MAC
         self.client_cmac = None
+        self.transport = None
 
     def init_logging(self):
         self.logging = SSTPLogging(self.logging, {
@@ -570,7 +571,10 @@ class SSTPProtocol(Protocol):
 
     def hello_timer_expired(self, close):
         if self.state == State.SERVER_CALL_DISCONNECTED:
-            self.transport.close()  # TODO: follow HTTP
+            if self.transport is not None:
+                self.transport.close()  # TODO: follow HTTP
+            else:
+                self.logging.warn('Rump connection.')
         elif close:
             self.logging.warn('Ping time out.')
             self.abort(ATTRIB_STATUS_NEGOTIATION_TIMEOUT)


### PR DESCRIPTION
In the Wild West that is the public Internet, you sometimes get a connection
that executes all or a part of the TLS handshake and then does nothing or
drops the connection. sstp-server starts a Hello timer as soon as a
connection is established, and it will expire some time after the client
drops the connection. Since the SSTPProtocol object doesn't have the
transport attribute when the Hello timer expires, an exception is generated.

BTW, a review of code should be performed since it's possible there's a
memory leak in these or other pathologic situations.