### PR TITLE
Support python-3.14

### DIFF
--- a/sstpd/__main__.py
+++ b/sstpd/__main__.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
 import sys
 import ssl
 import asyncio
 import logging
 import argparse
 from socket import IPPROTO_TCP, TCP_NODELAY
-from configparser import SafeConfigParser, NoSectionError
+from configparser import ConfigParser, NoSectionError
 from binascii import hexlify
 try:
     import uvloop
@@ -37,7 +36,7 @@ def _get_args():
             'log_level': logging.INFO
     }
     if args.conf_file:
-        config = SafeConfigParser()
+        config = ConfigParser()
         config.read(args.conf_file)
         try:
             defaults.update(dict(config.items(args.conf_section)))
@@ -152,7 +151,11 @@ def main():
     else:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         logging.info('Using uvloop')
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     factory = SSTPProtocolFactory(args,
                                   remote_pool=ippool,
                                   cert_hash=cert_hash)


### PR DESCRIPTION
* Update the name of the config parser class
* Properly handle the new event loop
* Fix the rpmlint/non-executable-script error